### PR TITLE
Use debhelper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 install:
- - sudo apt-get install -qq debhelper devscripts
+ - sudo apt-get install -qq debhelper devscripts libasound2-dev
 script:
  - publish/publish.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+publish/publish.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
+install:
+ - sudo apt-get install -qq debhelper yes
 script:
  - publish/publish.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 install:
- - sudo apt-get install -qq debhelper yes
+ - sudo apt-get install -qq debhelper
 script:
  - publish/publish.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 install:
  - sudo apt-get install -qq debhelper devscripts
 script:
- - publish/publish.sh < yes
+ - publish/publish.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
-publish/publish.sh
+script:
+ - publish/publish.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 install:
- - sudo apt-get install -qq debhelper
+ - sudo apt-get install -qq debhelper devscripts
 script:
  - publish/publish.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 install:
  - sudo apt-get install -qq debhelper devscripts
 script:
- - publish/publish.sh
+ - publish/publish.sh < yes

--- a/deb-functions.sh
+++ b/deb-functions.sh
@@ -14,29 +14,6 @@ function _run {
   fi
 }
 
-# function to create bdist and sdist from setup.py
-function python_package_full {
-  local SETUP_PATH=$1
-  local SETUP_SCRIPT=$2  # argument to script to act upon
-  cp ${SETUP_PATH}/${SETUP_SCRIPT} ${SETUP_PATH}/setup.py # copy SETUP_SCRIPT to setup.py
-  pushd ${SETUP_PATH}
-  python ${SETUP_PATH}/setup.py clean  # run setup.py clean
-  python ${SETUP_PATH}/setup.py bdist_egg # create binary
-  python ${SETUP_PATH}/setup.py sdist
-  rm ${SETUP_PATH}/setup.py
-  popd
-}
-
-function python_package_sdist {
-  local SETUP_PATH=$1
-  local SETUP_SCRIPT=$2  # argument to script to act upon
-  cp ${SETUP_SCRIPT} ${SETUP_PATH}/setup.py # copy SETUP_SCRIPT to setup.py
-  python ${SETUP_PATH}/setup.py clean  # run setup.py clean
-  python ${SETUP_PATH}/setup.py bdist_egg # create binary
-  python ${SETUP_PATH}/setup.py sdist
-  rm ${SETUP_PATH} setup.py
-}
-
 # setup init scripts
 function setup_init_script() {
   local NAME=$1
@@ -88,42 +65,14 @@ function pattern_replace {
   mv ${TMP_FILE} ${FILE}
 }
 
-function create_virtualenv {
-  local VIRTUALENV_ROOT=$1
-  if [ ! -d ${VIRTUALENV_ROOT} ]; then
-    mkdir -p $(dirname ${VIRTUALENV_ROOT})
-    virtualenv -p python2.7 ${VIRTUALENV_ROOT}
-  fi
-}
 
-function activate_virtualenv {
- local VIRTUALENV_ROOT=$1
- source ${VIRTUALENV_ROOT}/bin/activate
-}
 
-function s3_upload {
-  local SRC_DIR=$1
-  local S3_PATH=$2
-  local S3_VERSION_PATH=$3
-  pushd  ${SRC_DIR}/dist
-  _run s3cmd -c ${HOME}/.s3cfg.mycroft-artifact-writer sync --acl-public . ${S3_PATH}
-  echo ${VERSION} > latest
-  _run s3cmd -c ${HOME}/.s3cfg.mycroft-artifact-writer put --acl-public ${S3_VERSION_PATH}
-  popd
-}
 
-function git_clone_src {
-  local PROJECT_NAME=$1
-  local SRC_DEST=$2
-  local SRC_URL=$3
-  local SRC_BRANCH=$4
-  pushd ${SRC_DEST}
-  git clone ${SRC_URL}
-  cd ${PROJECT_NAME}
-  git checkout ${SRC_BRANCH}
-  VERSION="$(basename $(git describe --abbrev=0 --tags) | sed -e 's/v//g')"
-  popd
-}
+
+
+
+
+
 
 function git_clone_release {
   local PROJECT_NAME=$1
@@ -133,7 +82,7 @@ function git_clone_release {
   git clone ${SRC_URL}
   cd ${SRC_DEST}/${PROJECT_NAME}
   local VERSION="$(basename $(git describe --abbrev=0 --tags) | sed -e 's/v//g')"
-  git checkout release/${VERSION}
+  git checkout ${VERSION}
 }
 
 

--- a/deb-functions.sh
+++ b/deb-functions.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/bash
+
+# quiet option for s3 upload function
+if [ "$1" = "-q" ]; then
+  QUIET="echo"
+fi
+
+# funtion to run s3cmd
+function _run {
+  if [[ "$QUIET" ]]; then
+    echo "$*"
+  else
+    eval "$@"
+  fi
+}
+
+# function to create bdist and sdist from setup.py
+function python_package_full {
+  local SETUP_PATH=$1
+  local SETUP_SCRIPT=$2  # argument to script to act upon
+  cp ${SETUP_PATH}/${SETUP_SCRIPT} ${SETUP_PATH}/setup.py # copy SETUP_SCRIPT to setup.py
+  pushd ${SETUP_PATH}
+  python ${SETUP_PATH}/setup.py clean  # run setup.py clean
+  python ${SETUP_PATH}/setup.py bdist_egg # create binary
+  python ${SETUP_PATH}/setup.py sdist
+  rm ${SETUP_PATH}/setup.py
+  popd
+}
+
+function python_package_sdist {
+  local SETUP_PATH=$1
+  local SETUP_SCRIPT=$2  # argument to script to act upon
+  cp ${SETUP_SCRIPT} ${SETUP_PATH}/setup.py # copy SETUP_SCRIPT to setup.py
+  python ${SETUP_PATH}/setup.py clean  # run setup.py clean
+  python ${SETUP_PATH}/setup.py bdist_egg # create binary
+  python ${SETUP_PATH}/setup.py sdist
+  rm ${SETUP_PATH} setup.py
+}
+
+# setup init scripts
+function setup_init_script() {
+  local NAME=$1
+  echo "Creating init script for ${NAME}"
+  INIT_SCRIPT=${DEB_DIR}/mycroft-core.${NAME}.init
+  cp ${TOP}/*/deb_base/init.template ${INIT_SCRIPT}
+  pattern_replace ${INIT_SCRIPT} "%%NAME%%" "${NAME}"
+  pattern_replace ${INIT_SCRIPT} "%%DESCRIPTION%%" "${NAME}"
+  pattern_replace ${INIT_SCRIPT} "%%COMMAND%%" "\/usr\/local\/bin\/${NAME}"
+  pattern_replace ${INIT_SCRIPT} "%%USERNAME%%" "mycroft"
+  chmod a+x ${INIT_SCRIPT}
+}
+
+
+function create_source_path {
+  local SRC_PATH=$1
+  pushd ${TOP}
+  if [ ! -d ${SRC_PATH} ]; then
+    mkdir -p ${SRC_PATH}
+  fi
+  popd
+}
+
+function remove_source_path {
+  local SRC_PATH=$1
+  pushd ${TOP}
+  rm -Rvf ${SRC_PATH}
+  popd
+}
+
+function version_date {
+  local VERSION_PATH=$1
+  VERSION=$(date +%Y%m%d%H%M%S)
+  echo "version=\"${VERSION}\"" > ${VERSION_PATH}
+}
+
+function version_release {
+  local SRC_PATH=$1
+  local VERSION_PATH=$2
+  pushd ${SRC_PATH}
+}
+
+function pattern_replace {
+  local FILE=$1
+  local PATTERN=$2
+  local VALUE=$3
+  local TMP_FILE="/tmp/$$.replace"
+  cat ${FILE} | sed -e "s/${PATTERN}/${VALUE}/g" > ${TMP_FILE}
+  mv ${TMP_FILE} ${FILE}
+}
+
+function create_virtualenv {
+  local VIRTUALENV_ROOT=$1
+  if [ ! -d ${VIRTUALENV_ROOT} ]; then
+    mkdir -p $(dirname ${VIRTUALENV_ROOT})
+    virtualenv -p python2.7 ${VIRTUALENV_ROOT}
+  fi
+}
+
+function activate_virtualenv {
+ local VIRTUALENV_ROOT=$1
+ source ${VIRTUALENV_ROOT}/bin/activate
+}
+
+function s3_upload {
+  local SRC_DIR=$1
+  local S3_PATH=$2
+  local S3_VERSION_PATH=$3
+  pushd  ${SRC_DIR}/dist
+  _run s3cmd -c ${HOME}/.s3cfg.mycroft-artifact-writer sync --acl-public . ${S3_PATH}
+  echo ${VERSION} > latest
+  _run s3cmd -c ${HOME}/.s3cfg.mycroft-artifact-writer put --acl-public ${S3_VERSION_PATH}
+  popd
+}
+
+function git_clone_src {
+  local PROJECT_NAME=$1
+  local SRC_DEST=$2
+  local SRC_URL=$3
+  local SRC_BRANCH=$4
+  pushd ${SRC_DEST}
+  git clone ${SRC_URL}
+  cd ${PROJECT_NAME}
+  git checkout ${SRC_BRANCH}
+  VERSION="$(basename $(git describe --abbrev=0 --tags) | sed -e 's/v//g')"
+  popd
+}
+
+function git_clone_release {
+  local PROJECT_NAME=$1
+  local SRC_DEST=$2
+  local SRC_URL=$3
+  pushd ${SRC_DEST}
+  git clone ${SRC_URL}
+  cd ${SRC_DEST}/${PROJECT_NAME}
+  local VERSION="$(basename $(git describe --abbrev=0 --tags) | sed -e 's/v//g')"
+  git checkout release/${VERSION}
+}
+
+
+
+function install_pip {
+  local PIP_VERSION=$1
+  easy_install pip==${PIP_VERSION} # force version of pip
+}
+
+function build_dist_virtualenv {
+ARCH="$(dpkg --print-architecture)"
+SYSTEM_TARGET="/usr/local/"
+ARTIFACT_BASE="mycroft-core-${ARCH}-${VERSION}"
+MYCROFT_ARTIFACT_DIR=${MYCROFT_CORE_SRC}/build/${ARTIFACT_BASE}
+
+virtualenv --always-copy --clear ${MYCROFT_ARTIFACT_DIR}
+virtualenv --always-copy --clear --relocatable ${MYCROFT_ARTIFACT_DIR}
+
+virtualenv --always-copy --relocatable ${MYCROFT_ARTIFACT_DIR}
+}
+
+function create_deb_files {
+
+mkdir -p ${DEB_DIR}
+
+echo "Creating debian copyright file"
+COPYRIGHT_FILE=${DEB_DIR}/copyright
+cp ${TOP}/publish/deb_base/copyright.template ${COPYRIGHT_FILE}
+
+echo "Creating debian changelog file"
+CHANGELOG_FILE=${DEB_DIR}/changelog
+#CHANGELOG_FILE=${MYCROFT_CORE_SRC}/changelog
+cp ${TOP}/publish/deb_base/changelog.template ${CHANGELOG_FILE}
+pattern_replace ${CHANGELOG_FILE} "%%DATE%%" "${DATE}"
+pattern_replace ${CHANGELOG_FILE} "%%VERSION%%" "${VERSION}"
+
+echo "Creating debian compat file"
+COMPAT_FILE=${DEB_DIR}/compat
+echo "9" > ${COMPAT_FILE}
+
+echo "Creating debian rules file"
+RULES_FILE=${DEB_DIR}/rules
+cp ${TOP}/publish/deb_base/rules.template ${RULES_FILE}
+
+echo "Creating debian control file"
+# setup control file
+CONTROL_FILE=${DEB_DIR}/control
+cp ${TOP}/publish/deb_base/control.template ${CONTROL_FILE}
+pattern_replace ${CONTROL_FILE} "%%PACKAGE%%" "mimic"
+}

--- a/deb-functions.sh
+++ b/deb-functions.sh
@@ -81,7 +81,7 @@ function git_clone_release {
   pushd ${SRC_DEST}
   git clone ${SRC_URL}
   cd ${SRC_DEST}/${PROJECT_NAME}
-  local VERSION="$(basename $(git describe --abbrev=0 --tags) | sed -e 's/v//g')"
+  VERSION="$(basename $(git describe --abbrev=0 --tags) | sed -e 's/v//g')"
   git checkout ${VERSION}
 }
 

--- a/publish/control.template
+++ b/publish/control.template
@@ -1,0 +1,17 @@
+Source: %%PACKAGE%%
+Section: misc
+Priority: optional
+Maintainer: Arron Atchison <arron.atchison@mycroft.ai>
+Build-Depends: debhelper (>=9), python, dh-virtualenv, python-dev, python-setuptools, libffi-dev, libssl-dev, pulseaudio, portaudio19-dev, swig
+Standards-Version: 3.9.7
+
+Package: %%PACKAGE%%
+Priority: optional
+Architecture: any
+Depends: portaudio19-dev, libglib2.0-0, flac, espeak, mpg123, mimic, python, ${python:Depends}, ${shlibs:Depends}
+Description: The primary module that makes up the Mycroft Artificial Intelligence platform
+ Mycroft makes use of the Adapt Intent Parser, Speech-to-Text software, and
+ Text-to-Speech. The idea behind the platform is to be able to voice enable any
+ device and turn it into a smart personal assistant, able to perform a variety
+ of tasks.
+

--- a/publish/deb_base/changelog.template
+++ b/publish/deb_base/changelog.template
@@ -1,4 +1,4 @@
-mimic (%%VERSION%%) xenial; urgency=low
+mimic (%%VERSION%%~17.04) zesty; urgency=low
 
   * New upstream version
 

--- a/publish/deb_base/changelog.template
+++ b/publish/deb_base/changelog.template
@@ -1,0 +1,6 @@
+mimic (%%VERSION%%) xenial; urgency=low
+
+  * New upstream version
+
+ -- Mycroft Devs <devops@mycroft.ai>  %%DATE%%
+

--- a/publish/deb_base/control.template
+++ b/publish/deb_base/control.template
@@ -2,13 +2,13 @@ Source: %%PACKAGE%%
 Section: misc
 Priority: optional
 Maintainer: Arron Atchison <arron.atchison@mycroft.ai>
-Build-Depends: debhelper (>=9), build-essential, pkg-config, libasound2-dev
+Build-Depends: debhelper (>=9), build-essential, pkg-config, libasound2-dev, libicu-dev, automake, libtool
 Standards-Version: 3.9.7
 
 Package: %%PACKAGE%%
 Priority: optional
 Architecture: any
-Depends: pkg-config, libasound2-dev 
+Depends: pkg-config, libasound2-dev, libicu-dev, automake, libtool
 Description: Mimic is a fast, lightweight Text-to-speech engine
  developed by Mycroft A.I. and VocaliD, based on Carnegie Mellon
  University’s Flite (Festival-Lite) software. Mimic takes in

--- a/publish/deb_base/control.template
+++ b/publish/deb_base/control.template
@@ -2,7 +2,7 @@ Source: %%PACKAGE%%
 Section: misc
 Priority: optional
 Maintainer: Arron Atchison <arron.atchison@mycroft.ai>
-Build-Depends: debhelper (>=9), make, gcc, pkg-config, libasound2-dev
+Build-Depends: debhelper (>=9), build-essential, pkg-config, libasound2-dev
 Standards-Version: 3.9.7
 
 Package: %%PACKAGE%%

--- a/publish/deb_base/control.template
+++ b/publish/deb_base/control.template
@@ -1,4 +1,4 @@
-ource: %%PACKAGE%%
+Source: %%PACKAGE%%
 Section: misc
 Priority: optional
 Maintainer: Arron Atchison <arron.atchison@mycroft.ai>

--- a/publish/deb_base/control.template
+++ b/publish/deb_base/control.template
@@ -1,8 +1,16 @@
-Package: %%PACKAGE%%
-Version: %%VERSION%%
-Section: base
+ource: %%PACKAGE%%
+Section: misc
 Priority: optional
-Architecture: %%ARCHITECTURE%%
 Maintainer: Arron Atchison <arron.atchison@mycroft.ai>
-Description: %%DESCRIPTION%%
+Build-Depends: debhelper (>=9), make, gcc, pkg-config, libasound2-dev
+Standards-Version: 3.9.7
+
+Package: %%PACKAGE%%
+Priority: optional
+Architecture: any
+Depends: pkg-config, libasound2-dev 
+Description: Mimic is a fast, lightweight Text-to-speech engine
+ developed by Mycroft A.I. and VocaliD, based on Carnegie Mellon
+ University’s Flite (Festival-Lite) software. Mimic takes in
+ text and reads it out loud to create a high quality voice.
 

--- a/publish/deb_base/copyright.template
+++ b/publish/deb_base/copyright.template
@@ -1,0 +1,15 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+
+Files: *
+Copyright: 2016 Mycroft AI, Inc
+License: GPL-3+
+ Mycroft Core is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ Mycroft Core is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ You should have received a copy of the GNU General Public License
+ along with Mycroft Core.  If not, see <http://www.gnu.org/licenses/>.

--- a/publish/deb_base/rules.template
+++ b/publish/deb_base/rules.template
@@ -1,0 +1,9 @@
+#!/usr/bin/make -f
+# -*- makefile -*-
+
+# Uncomment this to turn on verbose mode.
+#export DH_VERBOSE=1
+
+%:
+       dh  $@
+

--- a/publish/deb_base/rules.template
+++ b/publish/deb_base/rules.template
@@ -7,3 +7,5 @@
 %:
 	dh  $@
 
+override_dh_auto_test:
+

--- a/publish/deb_base/rules.template
+++ b/publish/deb_base/rules.template
@@ -5,5 +5,5 @@
 #export DH_VERBOSE=1
 
 %:
-       dh  $@
+	dh  $@
 

--- a/publish/deb_base/rules.template
+++ b/publish/deb_base/rules.template
@@ -8,4 +8,6 @@
 	dh  $@
 
 override_dh_auto_test:
-
+override_dh_auto_configure:
+	./autogen.sh
+	dh_auto_configure

--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -21,7 +21,7 @@ DEB_DIR=${MIMIC_SRC}/debian
 create_deb_files
 
 cd ${TOP}/src
-tar -cvzf mimic.orig.tar.gz
+tar -cvzf mimic.orig.tar.gz mimic/
 
 cd ${MIMIC_SRC}
 debuild -us -uc

--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -20,5 +20,8 @@ DEB_DIR=${MIMIC_SRC}/debian
 
 create_deb_files
 
+cd ${TOP}/src
+tar -cvzf mimic.orig.tar.gz
+
 cd ${MIMIC_SRC}
 debuild -us -uc

--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -1,118 +1,24 @@
 #!/usr/bin/env bash
+# fail on any error
+set -Ee
+# source common functions
+source ../deb-functions.sh
+
 TOP=$(cd $(dirname $0)/.. && pwd -L)
-BUILD_DIR=${TOP}/build
-DIST_DIR=${TOP}/dist
-ARCH="$(dpkg --print-architecture)"
+MIMIC_SRC=${TOP}/src/mycroft-core
 
-if [ "$1" = "-q" ]; then
-  QUIET="echo"
-fi
+remove_source_path $MIMIC_SRC
+create_source_path $MIMIC_SRC
 
-# clean
-pushd ${TOP}
-rm -rf $DIST_DIR/*
-rm -rf $BUILD_DIR/*
-popd
+git_clone_release "mimic" "${TOP}/src" "https://github.com/MycroftAI/mimic.git"
 
-function _run() {
-  if [[ "$QUIET" ]]; then
-    echo "$*"
-  else
-    eval "$@"
-  fi
-}
+rm -rf ${MIMIC_SRC}/.git
 
-MIMIC_SRC=${TOP}/src
-rm -Rvf ${MIMIC_SRC}
-mkdir -p ${MIMIC_SRC}
-pushd ${MIMIC_SRC}
-git clone https://github.com/MycroftAI/mimic.git
-popd
-pushd $MIMIC_SRC/mimic
-VERSION="$(basename $(git describe --abbrev=0 --tags) | sed -e 's/v//g')"
-git checkout tags/${VERSION}
-popd
-echo $VERSION
-MIMIC_ARTIFACT_BASE="mimic-${ARCH}-${VERSION}"
-MIMIC_ARTIFACT_DIR=${BUILD_DIR}/${MIMIC_ARTIFACT_BASE}
-MIMIC_SYSTEM_TARGET="/usr/local"
-MIMIC_CONFIG_OPTIONS="--with-audio=alsa"
-echo $MIMIC_ARTIFACT_BASE
+VERSION="${VERSION}-1ppa1"
+DATE=$(date -R)
+DEB_DIR=${MIMIC_SRC}/debian
 
-function build_mimic() {
-  pushd $MIMIC_SRC/mimic
-  make clean
-  ./configure --prefix=${MIMIC_ARTIFACT_DIR}/${MIMIC_SYSTEM_TARGET} ${MIMIC_CONFIG_OPTIONS}
-  make && make install # -j ${nproc} 
-}
+create_deb_files
 
-
-#wget https://github.com/MycroftAI/mimic/archive/1.0.0.tar.gz
-
-build_mimic
-
-mkdir -p ${TOP}/dist
-pushd ${TOP}/build
-tar cvzf ${TOP}/dist/${MIMIC_ARTIFACT_BASE}.tar.gz -C ${TOP}/build/${MIMIC_ARTIFACT_BASE} .
-popd
-
-function replace() {
-  local FILE=$1
-  local PATTERN=$2
-  local VALUE=$3
-  local TMP_FILE="/tmp/$$.replace"
-  cat ${FILE} | sed -e "s/${PATTERN}/${VALUE}/g" > ${TMP_FILE}
-  mv ${TMP_FILE} ${FILE}
-}
-
-
-DEB_BASE="mimic-${ARCH}_${VERSION}-1"
-DEB_DIR=${TOP}/build/${DEB_BASE}
-mkdir -p ${DEB_DIR}/DEBIAN
-cp -rfv ${TOP}/build/${MIMIC_ARTIFACT_BASE}/* ${DEB_DIR}
-
-echo "Creating debian control file"
-# setup control file
-CONTROL_FILE=${DEB_DIR}/DEBIAN/control
-cp ${TOP}/publish/deb_base/control.template ${CONTROL_FILE}
-replace ${CONTROL_FILE} "%%PACKAGE%%" "mimic"
-replace ${CONTROL_FILE} "%%VERSION%%" "${VERSION}"
-replace ${CONTROL_FILE} "%%ARCHITECTURE%%" "${ARCH}"
-replace ${CONTROL_FILE} "%%DESCRIPTION%%" "mimic"
-#replace ${CONTROL_FILE} "%%PRE_DEPENDS%%" ""
-
-echo "Creating debian preinst file"
-PREINST_FILE=${DEB_DIR}/DEBIAN/preinst
-cp ${TOP}/publish/deb_base/preinst.template ${PREINST_FILE}
-replace ${PREINST_FILE} "%%INSTALL_USER%%" "mycroft"
-chmod 0755 ${PREINST_FILE}
-
-echo "Creating debian postinst file"
-POSTINST_FILE=${DEB_DIR}/DEBIAN/postinst
-cp ${TOP}/publish/deb_base/postinst.template ${POSTINST_FILE}
-replace ${POSTINST_FILE} "%%INSTALL_USER%%" "mycroft"
-chmod 0755 ${POSTINST_FILE}
-
-echo "Creating debian prerm file"
-PRERM_FILE=${DEB_DIR}/DEBIAN/prerm
-cp ${TOP}/publish/deb_base/prerm.template ${PRERM_FILE}
-#replace ${PRERM_FILE} "%%INSTALL_USER%%" "mycroft"
-chmod 0755 ${PRERM_FILE}
-
-echo "Creating debian postrm file"
-POSTRM_FILE=${DEB_DIR}/DEBIAN/postrm
-cp ${TOP}/publish/deb_base/postrm.template ${POSTRM_FILE}
-replace ${POSTRM_FILE} "%%INSTALL_USER%%" "mycroft"
-chmod 0755 ${POSTRM_FILE}
-
-
-pushd $(dirname ${DEB_DIR})
-dpkg-deb --build ${DEB_BASE}
-mv *.deb ${TOP}/dist
-popd
-
-
-cd ${TOP}/dist
-_run s3cmd -c ${HOME}/.s3cfg.mycroft-artifact-writer sync --acl-public . s3://bootstrap.mycroft.ai/artifacts/apt/${ARCH}/mimic/${VERSION}/
-echo ${VERSION} > latest
-_run s3cmd -c ${HOME}/.s3cfg.mycroft-artifact-writer put --acl-public ${TOP}/dist/latest s3://bootstrap.mycroft.ai/artifacts/apt/${ARCH}/mimic/
+cd ${MIMIC_SRC}
+debuild -us -uc

--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -2,10 +2,10 @@
 # fail on any error
 set -Ee
 # source common functions
-source ../deb-functions.sh
+source deb-functions.sh
 
 TOP=$(cd $(dirname $0)/.. && pwd -L)
-MIMIC_SRC=${TOP}/src/mycroft-core
+MIMIC_SRC=${TOP}/src/mimic
 
 remove_source_path $MIMIC_SRC
 create_source_path $MIMIC_SRC

--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -14,15 +14,23 @@ git_clone_release "mimic" "${TOP}/src" "https://github.com/MycroftAI/mimic.git"
 
 rm -rf ${MIMIC_SRC}/.git
 
+echo "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
+echo "Enter PPA Version:"
+
+read PPAVERSION
+
+echo "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%"
+
+
 VERSION_OLD=${VERSION}
-VERSION="${VERSION}-1ppa1"
+VERSION="${VERSION}-1ppa${PPAVERSION}"
 DATE=$(date -R)
 DEB_DIR=${MIMIC_SRC}/debian
 
 create_deb_files
 
 cd ${TOP}/src
-tar -cvzf "mimic_${VERSION_OLD}.orig.tar.gz" mimic/
+tar -cvzf "mimic-${VERSION_OLD}.orig.tar.gz" mimic/
 
 cd ${MIMIC_SRC}
-debuild -us -uc
+debuild -S -sa

--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -14,6 +14,7 @@ git_clone_release "mimic" "${TOP}/src" "https://github.com/MycroftAI/mimic.git"
 
 rm -rf ${MIMIC_SRC}/.git
 
+VERSION_OLD=${VERSION}
 VERSION="${VERSION}-1ppa1"
 DATE=$(date -R)
 DEB_DIR=${MIMIC_SRC}/debian
@@ -21,7 +22,7 @@ DEB_DIR=${MIMIC_SRC}/debian
 create_deb_files
 
 cd ${TOP}/src
-tar -cvzf mimic.orig.tar.gz mimic/
+tar -cvzf "mimic_${VERSION_OLD}.orig.tar.gz" mimic/
 
 cd ${MIMIC_SRC}
 debuild -us -uc


### PR DESCRIPTION
This updates the mimic packaging process to use debhelper. At the moment, the publish script creates a full unsigned deb package, but it can be easily changed by changing the debuild arguments to `-S -sa`.
