### PR TITLE
get latest tag from master not dev

### DIFF
--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -33,6 +33,7 @@ pushd ${MIMIC_SRC}
 git clone https://github.com/MycroftAI/mimic.git
 popd
 pushd $MIMIC_SRC/mimic
+git checkout master
 VERSION="$(basename $(git describe --abbrev=0 --tags) | sed -e 's/v//g')"
 git checkout tags/${VERSION}
 popd


### PR DESCRIPTION
Currently the script fetches the latest tag associated with the default branch which is development. This switches to the master branch so the latest tag from master is selected instead.

Alternate approach would be set the version tag to be the latest tag from any branch:
```
VERSION="$(basename $(git describe --tags $(git rev-list --tags --max-count=1)) | sed -e 's/v//g')"
```

However if we adhere to our release process all release tags should be made against master.